### PR TITLE
에이전트 실시간 활동 패널 + 카메라 팔로우 + 토큰 사용량

### DIFF
--- a/claudeville/adapters/claude.js
+++ b/claudeville/adapters/claude.js
@@ -64,6 +64,7 @@ function getSessionDetail(sessionId, projectPath) {
             else if (block.input.file_path) detail.lastToolInput = block.input.file_path.split('/').pop();
             else if (block.input.pattern) detail.lastToolInput = block.input.pattern;
             else if (block.input.query) detail.lastToolInput = block.input.query.substring(0, 40);
+            else if (block.input.recipient) detail.lastToolInput = block.input.recipient;
           }
         }
         if (!detail.lastMessage && block.type === 'text' && block.text) {
@@ -100,6 +101,7 @@ function getSubAgentDetail(filePath) {
             else if (block.input.file_path) detail.lastToolInput = block.input.file_path.split('/').pop();
             else if (block.input.pattern) detail.lastToolInput = block.input.pattern;
             else if (block.input.query) detail.lastToolInput = block.input.query.substring(0, 40);
+            else if (block.input.recipient) detail.lastToolInput = block.input.recipient;
           }
         }
         if (!detail.lastMessage && block.type === 'text' && block.text) {
@@ -167,6 +169,43 @@ function getRecentMessages(sessionFilePath, maxItems = 5) {
   return messages.slice(-maxItems);
 }
 
+function getTokenUsage(sessionFilePath) {
+  const usage = {
+    totalInput: 0,
+    totalOutput: 0,
+    cacheRead: 0,
+    cacheCreate: 0,
+    contextWindow: 0,  // 마지막 턴의 컨텍스트 크기
+    turnCount: 0,
+  };
+  try {
+    const lines = readLastLines(sessionFilePath, 200);
+    const entries = parseJsonLines(lines);
+
+    let lastUsage = null;
+    for (const entry of entries) {
+      const msg = entry.message;
+      if (!msg || !msg.usage) continue;
+      const u = msg.usage;
+      usage.totalInput += u.input_tokens || 0;
+      usage.totalOutput += u.output_tokens || 0;
+      usage.cacheRead += u.cache_read_input_tokens || 0;
+      usage.cacheCreate += u.cache_creation_input_tokens || 0;
+      usage.turnCount++;
+      lastUsage = u;
+    }
+
+    // 마지막 턴의 컨텍스트 = input + cache_read + cache_create
+    if (lastUsage) {
+      usage.contextWindow =
+        (lastUsage.input_tokens || 0) +
+        (lastUsage.cache_read_input_tokens || 0) +
+        (lastUsage.cache_creation_input_tokens || 0);
+    }
+  } catch { /* 무시 */ }
+  return usage;
+}
+
 function resolveSessionFilePath(sessionId, project) {
   if (!project) return null;
   const encoded = project.replace(/\//g, '-');
@@ -215,9 +254,16 @@ class ClaudeAdapter {
     const entries = parseJsonLines(lines);
     const now = Date.now();
     const sessionsMap = new Map();
+    const projectPathMap = new Map(); // 인코딩된 디렉토리명 → 실제 경로
 
     const HISTORY_SCAN_MS = 10 * 60 * 1000;
     for (const entry of entries) {
+      // 모든 엔트리에서 프로젝트 경로 맵 구축 (활성 여부 무관)
+      if (entry.project) {
+        const encoded = entry.project.replace(/\//g, '-');
+        projectPathMap.set(encoded, entry.project);
+      }
+
       if (!entry.sessionId) continue;
       if (now - (entry.timestamp || 0) > HISTORY_SCAN_MS) continue;
 
@@ -256,13 +302,20 @@ class ClaudeAdapter {
 
     mainSessions.sort((a, b) => b.lastActivity - a.lastActivity);
 
-    // 서브에이전트
-    const subAgents = this._getActiveSubAgents(activeThresholdMs);
+    // 서브에이전트 (프로젝트 경로 맵 전달)
+    const subAgents = this._getActiveSubAgents(activeThresholdMs, projectPathMap);
 
-    return [...mainSessions, ...subAgents];
+    // 고아 세션 (history.jsonl에 없고 subagents/에도 없는 팀 멤버 등)
+    const knownIds = new Set([
+      ...Array.from(sessionsMap.keys()),
+      ...subAgents.map(s => s.sessionId.replace('subagent-', '')),
+    ]);
+    const orphans = this._getOrphanSessions(activeThresholdMs, projectPathMap, knownIds);
+
+    return [...mainSessions, ...subAgents, ...orphans];
   }
 
-  _getActiveSubAgents(activeThresholdMs) {
+  _getActiveSubAgents(activeThresholdMs, projectPathMap = new Map()) {
     const projectsDir = path.join(CLAUDE_DIR, 'projects');
     if (!fs.existsSync(projectsDir)) return [];
 
@@ -300,7 +353,9 @@ class ClaudeAdapter {
 
             const agentId = agentFile.replace('agent-', '').replace('.jsonl', '');
             const detail = getSubAgentDetail(filePath);
-            const decodedProject = '/' + projDir.name.replace(/^-/, '').replace(/-/g, '/');
+            // projectPathMap에서 정확한 경로 조회, 없으면 폴백 (하이픈 포함 경로 깨짐 방지)
+            const decodedProject = projectPathMap.get(projDir.name)
+              || '/' + projDir.name.replace(/^-/, '').replace(/-/g, '/');
 
             results.push({
               sessionId: `subagent-${agentId}`,
@@ -324,12 +379,67 @@ class ClaudeAdapter {
     return results;
   }
 
+  _getOrphanSessions(activeThresholdMs, projectPathMap = new Map(), knownIds = new Set()) {
+    const projectsDir = path.join(CLAUDE_DIR, 'projects');
+    if (!fs.existsSync(projectsDir)) return [];
+
+    const now = Date.now();
+    const results = [];
+
+    try {
+      const projDirs = fs.readdirSync(projectsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+
+      for (const projDir of projDirs) {
+        const projPath = path.join(projectsDir, projDir.name);
+        let files;
+        try {
+          files = fs.readdirSync(projPath)
+            .filter(f => f.endsWith('.jsonl') && !f.startsWith('.'));
+        } catch { continue; }
+
+        for (const file of files) {
+          const sessionId = file.replace('.jsonl', '');
+          // 이미 알려진 세션이면 스킵
+          if (knownIds.has(sessionId)) continue;
+
+          const filePath = path.join(projPath, file);
+          let stat;
+          try { stat = fs.statSync(filePath); } catch { continue; }
+
+          if (now - stat.mtimeMs > activeThresholdMs) continue;
+
+          const detail = getSubAgentDetail(filePath);
+          const decodedProject = projectPathMap.get(projDir.name)
+            || '/' + projDir.name.replace(/^-/, '').replace(/-/g, '/');
+
+          results.push({
+            sessionId,
+            provider: 'claude',
+            agentId: sessionId,
+            agentType: 'team-member',
+            model: detail.model || 'unknown',
+            status: 'active',
+            lastActivity: stat.mtimeMs,
+            project: decodedProject,
+            lastMessage: detail.lastMessage,
+            lastTool: detail.lastTool,
+            lastToolInput: detail.lastToolInput,
+          });
+        }
+      }
+    } catch { /* 무시 */ }
+
+    return results;
+  }
+
   getSessionDetail(sessionId, project) {
     const filePath = resolveSessionFilePath(sessionId, project);
-    if (!filePath) return { toolHistory: [], messages: [] };
+    if (!filePath) return { toolHistory: [], messages: [], tokenUsage: null };
     return {
       toolHistory: getToolHistory(filePath),
       messages: getRecentMessages(filePath),
+      tokenUsage: getTokenUsage(filePath),
       sessionId,
     };
   }
@@ -342,7 +452,7 @@ class ClaudeAdapter {
       paths.push({ type: 'file', path: HISTORY_FILE });
     }
 
-    // 프로젝트 디렉토리
+    // 프로젝트 디렉토리 (recursive로 서브에이전트 파일도 감지)
     const projectsDir = path.join(CLAUDE_DIR, 'projects');
     if (fs.existsSync(projectsDir)) {
       try {
@@ -353,9 +463,20 @@ class ClaudeAdapter {
             type: 'directory',
             path: path.join(projectsDir, dir.name),
             filter: '.jsonl',
+            recursive: true,
           });
         }
       } catch { /* 무시 */ }
+    }
+
+    // 팀 디렉토리 감시 (팀 생성/변경 감지)
+    if (fs.existsSync(TEAMS_DIR)) {
+      paths.push({
+        type: 'directory',
+        path: TEAMS_DIR,
+        recursive: true,
+        filter: '.json',
+      });
     }
 
     return paths;

--- a/claudeville/css/activity-panel.css
+++ b/claudeville/css/activity-panel.css
@@ -1,0 +1,351 @@
+/* ─── 우측 실시간 활동 패널 ──────────────────────── */
+
+.activity-panel {
+    width: 320px;
+    flex-shrink: 0;
+    background: rgba(15, 15, 25, 0.98);
+    border-left: 2px solid rgba(232, 212, 77, 0.3);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: 'Press Start 2P', monospace;
+    animation: ap-slide-in 0.2s ease;
+}
+
+@keyframes ap-slide-in {
+    from { width: 0; opacity: 0; }
+    to { width: 320px; opacity: 1; }
+}
+
+/* ─── 헤더 ─────────────────────────────────────── */
+
+.activity-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(232, 212, 77, 0.15);
+    flex-shrink: 0;
+}
+
+.activity-panel__agent-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.activity-panel__name {
+    font-size: 10px;
+    color: #e8d44d;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.activity-panel__status {
+    font-size: 7px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.05);
+    white-space: nowrap;
+}
+
+.activity-panel__close {
+    font-size: 9px;
+    color: #8b8b9e;
+    background: transparent;
+    border: 1px solid rgba(139, 139, 158, 0.3);
+    border-radius: 3px;
+    padding: 3px 7px;
+    cursor: pointer;
+    font-family: inherit;
+    flex-shrink: 0;
+}
+
+.activity-panel__close:hover {
+    color: #ef4444;
+    border-color: #ef4444;
+}
+
+/* ─── 메타 정보 ────────────────────────────────── */
+
+.activity-panel__meta {
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(232, 212, 77, 0.1);
+    flex-shrink: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.activity-panel__meta-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.activity-panel__label {
+    font-size: 6px;
+    color: #8b8b9e;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.activity-panel__value {
+    font-size: 8px;
+    color: #e8d44d;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ─── 섹션 공통 ────────────────────────────────── */
+
+.activity-panel__section {
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(232, 212, 77, 0.05);
+    flex-shrink: 0;
+}
+
+.activity-panel__section--grow {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.activity-panel__section-title {
+    font-size: 7px;
+    color: #8b8b9e;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+
+/* ─── 현재 도구 ────────────────────────────────── */
+
+.activity-panel__current-tool {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 4px;
+    border-left: 3px solid #4ade80;
+}
+
+.activity-panel__current-tool--idle {
+    border-left-color: #60a5fa;
+}
+
+.activity-panel__tool-icon {
+    font-size: 14px;
+    flex-shrink: 0;
+}
+
+.activity-panel__tool-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.activity-panel__tool-name {
+    font-size: 8px;
+    color: #e8d44d;
+}
+
+.activity-panel__tool-input {
+    font-size: 7px;
+    color: #8b8b9e;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ─── 도구 히스토리 ────────────────────────────── */
+
+.activity-panel__tool-history {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.activity-panel__tool-history::-webkit-scrollbar {
+    width: 4px;
+}
+
+.activity-panel__tool-history::-webkit-scrollbar-thumb {
+    background: rgba(232, 212, 77, 0.2);
+    border-radius: 2px;
+}
+
+.activity-panel__tool-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    font-size: 7px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.activity-panel__tool-item:first-child {
+    background: rgba(74, 222, 128, 0.08);
+}
+
+.activity-panel__tool-item-icon {
+    flex-shrink: 0;
+    font-size: 10px;
+}
+
+.activity-panel__tool-item-name {
+    color: #e8d44d;
+    font-size: 7px;
+    white-space: nowrap;
+}
+
+.activity-panel__tool-item-detail {
+    color: #8b8b9e;
+    font-size: 6px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+/* ─── 메시지 ───────────────────────────────────── */
+
+.activity-panel__messages {
+    max-height: 140px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.activity-panel__messages::-webkit-scrollbar {
+    width: 4px;
+}
+
+.activity-panel__messages::-webkit-scrollbar-thumb {
+    background: rgba(232, 212, 77, 0.2);
+    border-radius: 2px;
+}
+
+.activity-panel__msg {
+    padding: 6px 8px;
+    font-size: 7px;
+    color: #8b8b9e;
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: 3px;
+    line-height: 1.6;
+    border-left: 2px solid transparent;
+}
+
+.activity-panel__msg--assistant {
+    border-left-color: #4ade80;
+}
+
+.activity-panel__msg--user {
+    border-left-color: #60a5fa;
+}
+
+.activity-panel__msg-role {
+    font-size: 6px;
+    color: #e8d44d;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 2px;
+}
+
+/* ─── 토큰 사용량 ─────────────────────────────── */
+
+.activity-panel__token-usage {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.activity-panel__token-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.activity-panel__token-label {
+    font-size: 7px;
+    color: #8b8b9e;
+}
+
+.activity-panel__token-value {
+    font-size: 9px;
+    color: #e8d44d;
+    font-weight: bold;
+}
+
+.activity-panel__token-value--cost {
+    color: #4ade80;
+}
+
+.activity-panel__context-bar-wrap {
+    width: 100%;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.activity-panel__context-bar {
+    height: 100%;
+    border-radius: 3px;
+    background: linear-gradient(90deg, #4ade80, #e8d44d);
+    transition: width 0.5s ease;
+}
+
+.activity-panel__context-bar--warning {
+    background: linear-gradient(90deg, #e8d44d, #f97316);
+}
+
+.activity-panel__context-bar--danger {
+    background: linear-gradient(90deg, #f97316, #ef4444);
+}
+
+.activity-panel__token-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+}
+
+.activity-panel__token-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 4px 6px;
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: 3px;
+}
+
+.activity-panel__token-cell-label {
+    font-size: 5px;
+    color: #8b8b9e;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.activity-panel__token-cell-value {
+    font-size: 8px;
+    color: #e8d44d;
+}
+
+/* ─── 비어있음 ────────────────────────────────── */
+
+.activity-panel__empty {
+    color: #555;
+    font-size: 7px;
+    padding: 4px 0;
+}

--- a/claudeville/index.html
+++ b/claudeville/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="css/modal.css">
     <link rel="stylesheet" href="css/character.css">
     <link rel="stylesheet" href="css/dashboard.css">
+    <link rel="stylesheet" href="css/activity-panel.css">
 </head>
 <body>
     <!-- 상단바 -->
@@ -91,39 +92,88 @@
                     </div>
                 </div>
             </div>
-        </div>
 
-        <!-- 에이전트 상세 패널 (main 안에서 flex로 배치) -->
-        <div id="agentDetail" class="agent-detail" style="display: none;">
-        <div class="agent-detail__header">
-            <span id="detailName" class="agent-detail__name"></span>
-            <span id="detailStatus" class="agent-detail__status"></span>
-            <button id="detailClose" class="agent-detail__close">X</button>
+            <!-- 우측 실시간 활동 패널 -->
+            <aside id="activityPanel" class="activity-panel" style="display: none;">
+                <div class="activity-panel__header">
+                    <div class="activity-panel__agent-info">
+                        <span id="panelAgentName" class="activity-panel__name"></span>
+                        <span id="panelAgentStatus" class="activity-panel__status"></span>
+                    </div>
+                    <button id="panelClose" class="activity-panel__close">X</button>
+                </div>
+                <div class="activity-panel__meta">
+                    <div class="activity-panel__meta-row">
+                        <span class="activity-panel__label" data-i18n="model">모델</span>
+                        <span id="panelModel" class="activity-panel__value"></span>
+                    </div>
+                    <div class="activity-panel__meta-row">
+                        <span class="activity-panel__label">Provider</span>
+                        <span id="panelProvider" class="activity-panel__value"></span>
+                    </div>
+                    <div class="activity-panel__meta-row">
+                        <span class="activity-panel__label" data-i18n="role">역할</span>
+                        <span id="panelRole" class="activity-panel__value"></span>
+                    </div>
+                    <div class="activity-panel__meta-row">
+                        <span class="activity-panel__label" data-i18n="team">팀</span>
+                        <span id="panelTeam" class="activity-panel__value"></span>
+                    </div>
+                </div>
+                <div class="activity-panel__section">
+                    <div class="activity-panel__section-title">Token Usage</div>
+                    <div id="panelTokenUsage" class="activity-panel__token-usage">
+                        <div class="activity-panel__token-row">
+                            <span class="activity-panel__token-label">Context</span>
+                            <span id="panelContextSize" class="activity-panel__token-value">-</span>
+                        </div>
+                        <div class="activity-panel__context-bar-wrap">
+                            <div id="panelContextBar" class="activity-panel__context-bar" style="width: 0%"></div>
+                        </div>
+                        <div class="activity-panel__token-grid">
+                            <div class="activity-panel__token-cell">
+                                <span class="activity-panel__token-cell-label">Input</span>
+                                <span id="panelInputTokens" class="activity-panel__token-cell-value">0</span>
+                            </div>
+                            <div class="activity-panel__token-cell">
+                                <span class="activity-panel__token-cell-label">Output</span>
+                                <span id="panelOutputTokens" class="activity-panel__token-cell-value">0</span>
+                            </div>
+                            <div class="activity-panel__token-cell">
+                                <span class="activity-panel__token-cell-label">Cache Read</span>
+                                <span id="panelCacheRead" class="activity-panel__token-cell-value">0</span>
+                            </div>
+                            <div class="activity-panel__token-cell">
+                                <span class="activity-panel__token-cell-label">Turns</span>
+                                <span id="panelTurnCount" class="activity-panel__token-cell-value">0</span>
+                            </div>
+                        </div>
+                        <div class="activity-panel__token-row">
+                            <span class="activity-panel__token-label">Est. Cost</span>
+                            <span id="panelEstCost" class="activity-panel__token-value activity-panel__token-value--cost">$0.00</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="activity-panel__section">
+                    <div class="activity-panel__section-title">Current Tool</div>
+                    <div id="panelCurrentTool" class="activity-panel__current-tool">
+                        <span class="activity-panel__tool-icon"></span>
+                        <div class="activity-panel__tool-detail">
+                            <span class="activity-panel__tool-name"></span>
+                            <span class="activity-panel__tool-input"></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="activity-panel__section activity-panel__section--grow">
+                    <div class="activity-panel__section-title">Tool History</div>
+                    <div id="panelToolHistory" class="activity-panel__tool-history"></div>
+                </div>
+                <div class="activity-panel__section">
+                    <div class="activity-panel__section-title">Messages</div>
+                    <div id="panelMessages" class="activity-panel__messages"></div>
+                </div>
+            </aside>
         </div>
-        <div class="agent-detail__body">
-            <div class="agent-detail__row">
-                <span data-i18n="model" class="agent-detail__label">모델</span>
-                <span id="detailModel" class="agent-detail__value"></span>
-            </div>
-            <div class="agent-detail__row">
-                <span data-i18n="role" class="agent-detail__label">역할</span>
-                <span id="detailRole" class="agent-detail__value"></span>
-            </div>
-            <div class="agent-detail__row">
-                <span data-i18n="tokens" class="agent-detail__label">토큰</span>
-                <span id="detailTokens" class="agent-detail__value"></span>
-            </div>
-            <div class="agent-detail__row">
-                <span data-i18n="cost" class="agent-detail__label">비용</span>
-                <span id="detailCostValue" class="agent-detail__value"></span>
-            </div>
-            <div class="agent-detail__row">
-                <span data-i18n="team" class="agent-detail__label">팀</span>
-                <span id="detailTeam" class="agent-detail__value"></span>
-            </div>
-            <div id="detailMessage" class="agent-detail__message"></div>
-        </div>
-    </div>
     </div>
 
     <!-- 모달 컨테이너 -->

--- a/claudeville/server.js
+++ b/claudeville/server.js
@@ -363,6 +363,7 @@ function sendInitialData(socket) {
     wsSend(socket, {
       type: 'init',
       sessions: getAllSessions(ACTIVE_THRESHOLD_MS),
+      teams: claudeAdapter ? claudeAdapter.getTeams() : [],
       timestamp: Date.now(),
     });
   } catch (err) {
@@ -378,6 +379,7 @@ function broadcastUpdate() {
     wsBroadcast({
       type: 'update',
       sessions: getAllSessions(ACTIVE_THRESHOLD_MS),
+      teams: claudeAdapter ? claudeAdapter.getTeams() : [],
       timestamp: Date.now(),
     });
   } catch (err) {

--- a/claudeville/src/application/AgentManager.js
+++ b/claudeville/src/application/AgentManager.js
@@ -6,6 +6,24 @@ export class AgentManager {
     constructor(world, dataSource) {
         this.world = world;
         this.dataSource = dataSource;
+        this._teamMembers = new Map();
+    }
+
+    _buildTeamMembers(teams) {
+        const teamMembers = new Map();
+        for (const team of teams) {
+            if (team.members) {
+                for (const member of team.members) {
+                    teamMembers.set(member.agentId, {
+                        name: member.name,
+                        teamName: team.teamName || team.name,
+                        agentType: member.agentType,
+                        model: member.model,
+                    });
+                }
+            }
+        }
+        return teamMembers;
     }
 
     async loadInitialData() {
@@ -15,23 +33,10 @@ export class AgentManager {
                 this.dataSource.getTeams(),
             ]);
 
-            // 팀 멤버 정보를 세션에 매핑
-            const teamMembers = new Map();
-            for (const team of teams) {
-                if (team.members) {
-                    for (const member of team.members) {
-                        teamMembers.set(member.agentId, {
-                            name: member.name,
-                            teamName: team.teamName || team.name,
-                            agentType: member.agentType,
-                            model: member.model,
-                        });
-                    }
-                }
-            }
+            this._teamMembers = this._buildTeamMembers(teams);
 
             for (const session of sessions) {
-                this._upsertAgent(session, teamMembers);
+                this._upsertAgent(session, this._teamMembers);
             }
 
             console.log(`[AgentManager] ${this.world.agents.size}개 에이전트 로드 완료`);
@@ -43,11 +48,16 @@ export class AgentManager {
     handleWebSocketMessage(data) {
         if (!data.sessions) return;
 
+        // 팀 데이터가 포함되어 있으면 갱신
+        if (data.teams) {
+            this._teamMembers = this._buildTeamMembers(data.teams);
+        }
+
         const currentIds = new Set();
 
         for (const session of data.sessions) {
             currentIds.add(session.sessionId);
-            this._upsertAgent(session, null);
+            this._upsertAgent(session, this._teamMembers);
         }
 
         // 서버 목록에 없는 에이전트 처리
@@ -72,10 +82,15 @@ export class AgentManager {
         const id = session.sessionId;
         const teamInfo = teamMembers ? teamMembers.get(session.agentId) : null;
 
+        // 팀 이름: teamInfo에서 가져오거나, 프로젝트 경로에서 추출
+        const teamName = teamInfo?.teamName
+            || (session.project ? session.project.split('/').filter(Boolean).pop() : null);
+
         const agentData = {
             model: teamInfo?.model || session.model || 'unknown',
             status: this._resolveStatus(session),
             role: teamInfo?.agentType || session.agentType || 'general',
+            teamName,
             currentTool: session.lastTool || null,
             currentToolInput: session.lastToolInput || null,
             _lastMessage: session.lastMessage || null,
@@ -90,7 +105,7 @@ export class AgentManager {
                 model: agentData.model,
                 status: agentData.status,
                 role: agentData.role,
-                teamName: teamInfo?.teamName || null,
+                teamName,
                 projectPath: session.project || null,
                 lastTool: session.lastTool,
                 lastToolInput: session.lastToolInput,

--- a/claudeville/src/presentation/App.js
+++ b/claudeville/src/presentation/App.js
@@ -18,6 +18,7 @@ import { TopBar } from './shared/TopBar.js';
 import { Sidebar } from './shared/Sidebar.js';
 import { Toast } from './shared/Toast.js';
 import { Modal } from './shared/Modal.js';
+import { ActivityPanel } from './shared/ActivityPanel.js';
 
 class App {
     constructor() {
@@ -34,6 +35,7 @@ class App {
         this.modal = null;
         this.renderer = null;
         this.dashboardRenderer = null;
+        this.activityPanel = null;
     }
 
     async boot() {
@@ -79,8 +81,9 @@ class App {
             // 8-1. 대시보드 렌더러 로드
             await this._loadDashboard();
 
-            // 9. 에이전트 선택 → 상세패널
-            this._bindAgentDetail();
+            // 9. 우측 실시간 활동 패널
+            this.activityPanel = new ActivityPanel();
+            this._bindAgentFollow();
 
             // 10. 설정 버튼
             this._bindSettings();
@@ -129,38 +132,19 @@ class App {
         }
     }
 
-    _bindAgentDetail() {
-        const detailEl = document.getElementById('agentDetail');
-        const closeBtn = document.getElementById('detailClose');
-
+    _bindAgentFollow() {
+        // 에이전트 선택 시 카메라 팔로우
         eventBus.on('agent:selected', (agent) => {
-            document.getElementById('detailName').textContent = agent.name;
-            document.getElementById('detailModel').textContent = agent.model;
-            document.getElementById('detailRole').textContent = agent.role;
-            document.getElementById('detailTokens').textContent =
-                `${agent.tokens.input + agent.tokens.output}`;
-            document.getElementById('detailCostValue').textContent =
-                `$${agent.cost.toFixed(4)}`;
-            document.getElementById('detailTeam').textContent =
-                agent.teamName || '-';
-
-            const statusEl = document.getElementById('detailStatus');
-            statusEl.textContent = agent.status.toUpperCase();
-            statusEl.style.color = {
-                working: '#4ade80',
-                idle: '#60a5fa',
-                waiting: '#f97316',
-            }[agent.status] || '#8b8b9e';
-
-            const msgEl = document.getElementById('detailMessage');
-            msgEl.textContent = agent.lastMessage
-                ? `"${agent.lastMessage}"` : '';
-
-            detailEl.style.display = '';
+            if (agent && this.renderer) {
+                this.renderer.selectAgentById(agent.id);
+            }
         });
 
-        closeBtn.addEventListener('click', () => {
-            detailEl.style.display = 'none';
+        // 패널 닫기 시 팔로우 해제
+        eventBus.on('agent:deselected', () => {
+            if (this.renderer) {
+                this.renderer.selectAgentById(null);
+            }
         });
     }
 

--- a/claudeville/src/presentation/character-mode/AgentSprite.js
+++ b/claudeville/src/presentation/character-mode/AgentSprite.js
@@ -19,6 +19,12 @@ export class AgentSprite {
         this.statusAnim = 0;
         this._lastBuildingType = null;
 
+        // 대화 시스템
+        this.chatPartner = null;     // 대화 상대 AgentSprite
+        this.chatting = false;       // 대화 중 여부
+        this.chatTimer = 0;          // 대화 애니메이션 타이머
+        this.chatBubbleAnim = 0;     // 말풍선 애니메이션
+
         const screen = agent.position.toScreen(TILE_WIDTH, TILE_HEIGHT);
         this.x = screen.x;
         this.y = screen.y;
@@ -27,6 +33,15 @@ export class AgentSprite {
     }
 
     _pickTarget() {
+        // 대화 상대가 있으면 상대 위치로 이동
+        if (this.chatPartner) {
+            this.targetX = this.chatPartner.x + (this.x < this.chatPartner.x ? -25 : 25);
+            this.targetY = this.chatPartner.y;
+            this.moving = true;
+            this.waitTimer = 0;
+            return;
+        }
+
         // WORKING일 때만 도구 기반 이동, IDLE/WAITING이면 자유 이동
         const isWorking = this.agent.status === AgentStatus.WORKING;
         const buildingType = isWorking ? this.agent.targetBuildingType : null;
@@ -67,14 +82,51 @@ export class AgentSprite {
     update(particleSystem) {
         this.statusAnim += 0.05;
 
+        // 대화 중 상태 처리
+        if (this.chatting) {
+            this.chatBubbleAnim += 0.06;
+            // 대화 상대가 가까이 있으면 서로 마주보기
+            if (this.chatPartner) {
+                this.facingLeft = this.chatPartner.x < this.x;
+            }
+            return; // 대화 중엔 이동 안 함
+        }
+
+        // 대화 상대를 향해 이동 중 → 가까워지면 대화 시작
+        if (this.chatPartner) {
+            const cpDx = this.chatPartner.x - this.x;
+            const cpDy = this.chatPartner.y - this.y;
+            const cpDist = Math.sqrt(cpDx * cpDx + cpDy * cpDy);
+            if (cpDist < 35) {
+                this.chatting = true;
+                this.chatBubbleAnim = 0;
+                this.moving = false;
+                this.walkFrame = 0;
+                this.facingLeft = cpDx < 0;
+                // 상대도 대화 상태로
+                if (!this.chatPartner.chatting) {
+                    this.chatPartner.chatPartner = this;
+                    this.chatPartner.chatting = true;
+                    this.chatPartner.chatBubbleAnim = 0;
+                    this.chatPartner.moving = false;
+                    this.chatPartner.walkFrame = 0;
+                    this.chatPartner.facingLeft = cpDx > 0;
+                }
+                return;
+            }
+            // 상대 위치가 변하면 타겟 갱신
+            this.targetX = this.chatPartner.x + (this.x < this.chatPartner.x ? -25 : 25);
+            this.targetY = this.chatPartner.y;
+        }
+
         // WORKING 상태에서 도구가 바뀌면 즉시 새 건물로 방향 전환
-        if (this.agent.status === AgentStatus.WORKING) {
+        if (this.agent.status === AgentStatus.WORKING && !this.chatPartner) {
             const curBuilding = this.agent.targetBuildingType;
             if (curBuilding && curBuilding !== this._lastBuildingType) {
                 this._lastBuildingType = curBuilding;
                 this._pickTarget();
             }
-        } else {
+        } else if (!this.chatPartner) {
             this._lastBuildingType = null;
         }
 
@@ -97,12 +149,12 @@ export class AgentSprite {
 
         if (dist < 2) {
             this.moving = false;
-            this.waitTimer = 60 + Math.floor(Math.random() * 180);
+            this.waitTimer = this.chatPartner ? 10 : 60 + Math.floor(Math.random() * 180);
             this.walkFrame = 0;
             return;
         }
 
-        const speed = 1.5;
+        const speed = this.chatPartner ? 2.5 : 1.5; // 대화하러 갈 땐 좀 더 빨리
         this.x += (dx / dist) * speed;
         this.y += (dy / dist) * speed;
         this.walkFrame += 0.15;
@@ -111,6 +163,22 @@ export class AgentSprite {
         if (particleSystem && Math.random() < 0.3) {
             particleSystem.spawn('footstep', this.x, this.y + 16, 1);
         }
+    }
+
+    /** 대화 시작 (IsometricRenderer에서 호출) */
+    startChat(partnerSprite) {
+        this.chatPartner = partnerSprite;
+        this.chatting = false;
+        this.chatBubbleAnim = 0;
+        this._pickTarget(); // 상대에게 이동 시작
+    }
+
+    /** 대화 종료 */
+    endChat() {
+        this.chatPartner = null;
+        this.chatting = false;
+        this.chatBubbleAnim = 0;
+        this._pickTarget(); // 원래 행동 복귀
     }
 
     draw(ctx, zoom = 1) {
@@ -180,8 +248,15 @@ export class AgentSprite {
 
         ctx.restore();
 
+        // 대화 중 이펙트
+        if (this.chatting) {
+            this._drawChatEffect(ctx);
+        }
+
         // Status indicators (drawn without flip, zoom-independent)
-        this._drawStatus(ctx);
+        if (!this.chatting) {
+            this._drawStatus(ctx);
+        }
         this._drawNameTag(ctx);
     }
 
@@ -411,6 +486,54 @@ export class AgentSprite {
         ctx.lineTo(-hw - r, -10 + r);
         ctx.quadraticCurveTo(-hw - r, -10, -hw, -10);
         ctx.closePath();
+    }
+
+    _drawChatEffect(ctx) {
+        ctx.save();
+        const s = 1 / (this._zoom || 1);
+        ctx.translate(this.x, this.y);
+        ctx.scale(s, s);
+
+        const t = this.chatBubbleAnim;
+
+        // 말풍선 (번갈아 나타나는 효과)
+        const phase = Math.floor(t * 1.5) % 3;
+        const bubbleY = -38;
+
+        // 배경 원
+        ctx.fillStyle = 'rgba(26, 26, 46, 0.92)';
+        ctx.strokeStyle = '#4ade80';
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(0, bubbleY, 14, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        // 꼬리
+        ctx.fillStyle = 'rgba(26, 26, 46, 0.92)';
+        ctx.beginPath();
+        ctx.moveTo(-3, bubbleY + 12);
+        ctx.lineTo(0, bubbleY + 18);
+        ctx.lineTo(3, bubbleY + 12);
+        ctx.fill();
+
+        // 대화 아이콘 (말풍선 안에 점점점 애니메이션)
+        ctx.fillStyle = '#4ade80';
+        ctx.font = 'bold 12px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        const dots = ['.', '..', '...'][phase];
+        ctx.fillText(dots, 0, bubbleY - 1);
+
+        // 위에 떠다니는 이모지 파티클
+        const floatY = -56 + Math.sin(t * 2) * 4;
+        ctx.globalAlpha = 0.5 + 0.3 * Math.sin(t * 3);
+        ctx.font = '12px sans-serif';
+        const emojis = ['\u{1F4AC}', '\u{1F4AD}', '\u2728'];
+        ctx.fillText(emojis[Math.floor(t) % emojis.length], 0, floatY);
+        ctx.globalAlpha = 1;
+
+        ctx.restore();
     }
 
     _drawNameTag(ctx) {

--- a/claudeville/src/presentation/character-mode/Camera.js
+++ b/claudeville/src/presentation/character-mode/Camera.js
@@ -14,6 +14,10 @@ export class Camera {
         this.camStartX = 0;
         this.camStartY = 0;
 
+        // Follow 메커니즘
+        this.followTarget = null;      // AgentSprite 참조
+        this.followSmoothing = 0.08;   // lerp 계수 (낮을수록 부드러움)
+
         this._onMouseDown = this._onMouseDown.bind(this);
         this._onMouseMove = this._onMouseMove.bind(this);
         this._onMouseUp = this._onMouseUp.bind(this);
@@ -46,6 +50,22 @@ export class Camera {
         this.canvas.removeEventListener('wheel', this._onWheel);
     }
 
+    followAgent(sprite) {
+        this.followTarget = sprite;
+    }
+
+    stopFollow() {
+        this.followTarget = null;
+    }
+
+    updateFollow() {
+        if (!this.followTarget) return;
+        const targetX = -this.followTarget.x + this.canvas.width / (2 * this.zoom);
+        const targetY = -this.followTarget.y + this.canvas.height / (2 * this.zoom);
+        this.x += (targetX - this.x) * this.followSmoothing;
+        this.y += (targetY - this.y) * this.followSmoothing;
+    }
+
     _onMouseDown(e) {
         if (e.button !== 0) return;
         this.dragging = true;
@@ -54,6 +74,8 @@ export class Camera {
         this.camStartX = this.x;
         this.camStartY = this.y;
         this.canvas.style.cursor = 'grabbing';
+        // 드래그 시작하면 팔로우 해제
+        if (this.followTarget) this.stopFollow();
     }
 
     _onMouseMove(e) {

--- a/claudeville/src/presentation/character-mode/IsometricRenderer.js
+++ b/claudeville/src/presentation/character-mode/IsometricRenderer.js
@@ -196,9 +196,11 @@ export class IsometricRenderer {
         if (clicked) {
             clicked.selected = true;
             this.selectedAgent = clicked.agent;
+            this.camera.followAgent(clicked);
             if (this.onAgentSelect) this.onAgentSelect(clicked.agent);
         } else {
             this.selectedAgent = null;
+            this.camera.stopFollow();
             if (this.onAgentSelect) this.onAgentSelect(null);
         }
     }
@@ -210,8 +212,70 @@ export class IsometricRenderer {
         this.frameId = requestAnimationFrame(() => this._loop());
     }
 
+    _updateChatMatching() {
+        // 현재 SendMessage 사용 중인 에이전트 찾기
+        const senders = new Set();
+
+        for (const sprite of this.agentSprites.values()) {
+            const agent = sprite.agent;
+            if (agent.currentTool === 'SendMessage' && agent.currentToolInput) {
+                senders.add(sprite);
+
+                // 이미 대화 중이면 스킵
+                if (sprite.chatPartner) continue;
+
+                // 수신자 이름으로 스프라이트 찾기
+                const recipientName = agent.currentToolInput;
+                let target = null;
+                for (const other of this.agentSprites.values()) {
+                    if (other === sprite) continue;
+                    if (other.agent.name === recipientName) {
+                        target = other;
+                        break;
+                    }
+                }
+
+                if (target) {
+                    sprite.startChat(target);
+                }
+            }
+        }
+
+        // SendMessage가 아닌 에이전트의 대화 상태 해제
+        for (const sprite of this.agentSprites.values()) {
+            if (sprite.chatPartner && !senders.has(sprite)) {
+                // 상대방이 아직 SendMessage 중이면 유지
+                if (sprite.chatPartner.agent.currentTool === 'SendMessage') continue;
+                sprite.endChat();
+            }
+        }
+    }
+
+    selectAgentById(agentId) {
+        for (const sprite of this.agentSprites.values()) {
+            sprite.selected = false;
+        }
+        if (agentId) {
+            const sprite = this.agentSprites.get(agentId);
+            if (sprite) {
+                sprite.selected = true;
+                this.selectedAgent = sprite.agent;
+                this.camera.followAgent(sprite);
+                return;
+            }
+        }
+        this.selectedAgent = null;
+        this.camera.stopFollow();
+    }
+
     _update() {
         this.waterFrame += 0.03;
+
+        // 카메라 팔로우 업데이트
+        if (this.camera) this.camera.updateFollow();
+
+        // 대화 매칭: SendMessage 사용 중인 에이전트 → 수신자 스프라이트로 이동
+        this._updateChatMatching();
 
         // Update agent sprites
         for (const sprite of this.agentSprites.values()) {

--- a/claudeville/src/presentation/shared/ActivityPanel.js
+++ b/claudeville/src/presentation/shared/ActivityPanel.js
@@ -1,0 +1,244 @@
+import { eventBus } from '../../domain/events/DomainEvent.js';
+
+const TOOL_ICONS = {
+    Read: '\u{1F4D6}', Edit: '\u270F\uFE0F', Write: '\u{1F4DD}',
+    Grep: '\u{1F50D}', Glob: '\u{1F4C1}', Bash: '\u26A1',
+    Task: '\u{1F4CB}', TaskCreate: '\u{1F4CB}', TaskUpdate: '\u{1F4CB}', TaskList: '\u{1F4CB}',
+    WebSearch: '\u{1F310}', WebFetch: '\u{1F310}',
+    SendMessage: '\u{1F4AC}', TeamCreate: '\u{1F465}',
+    EnterPlanMode: '\u{1F4D0}', ExitPlanMode: '\u{1F4D0}',
+    AskUserQuestion: '\u2753',
+};
+
+export class ActivityPanel {
+    constructor() {
+        this.panelEl = document.getElementById('activityPanel');
+        this.closeBtn = document.getElementById('panelClose');
+        this.currentAgent = null;
+        this._pollTimer = null;
+
+        this._bind();
+    }
+
+    _bind() {
+        this.closeBtn.addEventListener('click', () => this.hide());
+
+        eventBus.on('agent:selected', (agent) => {
+            if (agent) this.show(agent);
+        });
+
+        eventBus.on('agent:updated', (agent) => {
+            if (this.currentAgent && agent.id === this.currentAgent.id) {
+                this.currentAgent = agent;
+                this._updateInfo(agent);
+                this._updateCurrentTool(agent);
+            }
+        });
+
+        eventBus.on('agent:removed', (agent) => {
+            if (this.currentAgent && agent.id === this.currentAgent.id) {
+                this.hide();
+            }
+        });
+    }
+
+    show(agent) {
+        this.currentAgent = agent;
+        this.panelEl.style.display = '';
+        this._updateInfo(agent);
+        this._updateCurrentTool(agent);
+        this._startPolling();
+    }
+
+    hide() {
+        this.panelEl.style.display = 'none';
+        this.currentAgent = null;
+        this._stopPolling();
+        eventBus.emit('agent:deselected');
+    }
+
+    _updateInfo(agent) {
+        document.getElementById('panelAgentName').textContent = agent.name;
+        const statusEl = document.getElementById('panelAgentStatus');
+        statusEl.textContent = agent.status.toUpperCase();
+        statusEl.style.color = {
+            working: '#4ade80', idle: '#60a5fa', waiting: '#f97316',
+        }[agent.status] || '#8b8b9e';
+
+        document.getElementById('panelModel').textContent =
+            (agent.model || '').replace('claude-', '').replace(/-2025\d+/, '');
+        document.getElementById('panelProvider').textContent = agent.provider || 'claude';
+        document.getElementById('panelRole').textContent = agent.role || 'general';
+        document.getElementById('panelTeam').textContent = agent.teamName || '-';
+    }
+
+    _updateCurrentTool(agent) {
+        const container = document.getElementById('panelCurrentTool');
+        const iconEl = container.querySelector('.activity-panel__tool-icon');
+        const nameEl = container.querySelector('.activity-panel__tool-name');
+        const inputEl = container.querySelector('.activity-panel__tool-input');
+
+        if (agent.currentTool) {
+            container.classList.remove('activity-panel__current-tool--idle');
+            iconEl.textContent = this._icon(agent.currentTool);
+            nameEl.textContent = agent.currentTool;
+            inputEl.textContent = agent.currentToolInput || '';
+        } else {
+            container.classList.add('activity-panel__current-tool--idle');
+            iconEl.textContent = agent.status === 'idle' ? '\u{1F4A4}' : '\u23F3';
+            nameEl.textContent = agent.status === 'idle' ? 'Idle' : 'Waiting...';
+            inputEl.textContent = '';
+        }
+    }
+
+    // ─── 실시간 폴링 ────────────────────────────────
+
+    _startPolling() {
+        this._stopPolling();
+        this._fetchDetail();
+        this._pollTimer = setInterval(() => this._fetchDetail(), 2000);
+    }
+
+    _stopPolling() {
+        if (this._pollTimer) {
+            clearInterval(this._pollTimer);
+            this._pollTimer = null;
+        }
+    }
+
+    async _fetchDetail() {
+        if (!this.currentAgent) return;
+        const agent = this.currentAgent;
+        try {
+            const params = new URLSearchParams({
+                sessionId: agent.id,
+                project: agent.projectPath || '',
+                provider: agent.provider || 'claude',
+            });
+            const resp = await fetch(`/api/session-detail?${params}`);
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (this.currentAgent && this.currentAgent.id === agent.id) {
+                this._renderToolHistory(data.toolHistory || []);
+                this._renderMessages(data.messages || []);
+                this._renderTokenUsage(data.tokenUsage);
+            }
+        } catch {
+            // 네트워크 에러 무시
+        }
+    }
+
+    // ─── 렌더링 ─────────────────────────────────────
+
+    _renderToolHistory(tools) {
+        const el = document.getElementById('panelToolHistory');
+        if (!tools.length) {
+            el.innerHTML = '<div class="activity-panel__empty">No tool usage</div>';
+            return;
+        }
+        const reversed = [...tools].reverse();
+        el.innerHTML = reversed.map(t => {
+            const icon = this._icon(t.tool);
+            const name = this._shortTool(t.tool);
+            const detail = t.detail ? this._esc(this._trunc(t.detail, 45)) : '';
+            return `<div class="activity-panel__tool-item">
+                <span class="activity-panel__tool-item-icon">${icon}</span>
+                <span class="activity-panel__tool-item-name">${this._esc(name)}</span>
+                <span class="activity-panel__tool-item-detail">${detail}</span>
+            </div>`;
+        }).join('');
+    }
+
+    _renderMessages(messages) {
+        const el = document.getElementById('panelMessages');
+        if (!messages.length) {
+            el.innerHTML = '<div class="activity-panel__empty">No messages</div>';
+            return;
+        }
+        const reversed = [...messages].reverse();
+        el.innerHTML = reversed.map(m => {
+            const cls = m.role === 'assistant' ? 'assistant' : 'user';
+            return `<div class="activity-panel__msg activity-panel__msg--${cls}">
+                <div class="activity-panel__msg-role">${m.role}</div>
+                <div>${this._esc(m.text)}</div>
+            </div>`;
+        }).join('');
+    }
+
+    _renderTokenUsage(usage) {
+        if (!usage) return;
+
+        const MAX_CONTEXT = 200000; // Opus 200k context window
+        const contextPct = Math.min(100, (usage.contextWindow / MAX_CONTEXT) * 100);
+
+        // Context size (읽기 쉬운 형태)
+        document.getElementById('panelContextSize').textContent =
+            this._formatTokens(usage.contextWindow) + ` / ${this._formatTokens(MAX_CONTEXT)}`;
+
+        // Context bar
+        const bar = document.getElementById('panelContextBar');
+        bar.style.width = contextPct + '%';
+        bar.className = 'activity-panel__context-bar';
+        if (contextPct > 80) bar.classList.add('activity-panel__context-bar--danger');
+        else if (contextPct > 50) bar.classList.add('activity-panel__context-bar--warning');
+
+        // Token cells
+        document.getElementById('panelInputTokens').textContent =
+            this._formatTokens(usage.totalInput);
+        document.getElementById('panelOutputTokens').textContent =
+            this._formatTokens(usage.totalOutput);
+        document.getElementById('panelCacheRead').textContent =
+            this._formatTokens(usage.cacheRead);
+        document.getElementById('panelTurnCount').textContent =
+            usage.turnCount.toLocaleString();
+
+        // Estimated cost (Opus 4.6 기본 요금)
+        const cost = this._estimateCost(usage);
+        document.getElementById('panelEstCost').textContent = `$${cost.toFixed(4)}`;
+    }
+
+    _formatTokens(n) {
+        if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+        if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+        return String(n);
+    }
+
+    _estimateCost(usage) {
+        // Opus 4.6 pricing: input $15/M, output $75/M, cache_read $1.5/M, cache_create $18.75/M
+        return (
+            (usage.totalInput * 15 / 1000000) +
+            (usage.totalOutput * 75 / 1000000) +
+            (usage.cacheRead * 1.5 / 1000000) +
+            (usage.cacheCreate * 18.75 / 1000000)
+        );
+    }
+
+    // ─── 유틸 ───────────────────────────────────────
+
+    _icon(tool) {
+        if (!tool) return '\u2753';
+        if (tool.startsWith('mcp__playwright__')) return '\u{1F3AD}';
+        if (tool.startsWith('mcp__')) return '\u{1F50C}';
+        return TOOL_ICONS[tool] || '\u{1F527}';
+    }
+
+    _shortTool(name) {
+        if (!name) return '';
+        return name.replace('mcp__playwright__', 'pw:').replace('mcp__', '');
+    }
+
+    _trunc(s, max) {
+        return s.length > max ? s.substring(0, max - 1) + '...' : s;
+    }
+
+    _esc(s) {
+        if (!s) return '';
+        const d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    destroy() {
+        this._stopPolling();
+    }
+}


### PR DESCRIPTION
## Summary
- 에이전트 클릭 시 카메라가 부드럽게 따라가는 follow 메커니즘 (lerp 기반, 드래그 시 해제)
- 우측 실시간 활동 패널: 도구 히스토리, 메시지, 토큰 사용량을 2초 주기로 폴링
- 토큰 사용량 실시간 표시: 컨텍스트 프로그레스 바 (50%주황/80%빨강), input/output/cache, 예상 비용
- SendMessage 사용 시 캐릭터가 상대에게 걸어가서 대화하는 애니메이션
- 팀 멤버 감지 개선: history.jsonl/subagents 외 프로젝트 디렉토리 .jsonl 직접 스캔 (고아 세션 감지)
- 프로젝트 경로 디코딩 버그 수정 (하이픈 포함 경로 깨짐 방지)
- WebSocket 메시지에 teams 데이터 포함하여 팀 정보 실시간 전파

## 변경 파일 (10개)
- `adapters/claude.js` — 토큰 사용량 집계, 고아 세션 스캔, recipient 추출, 경로 디코딩 수정
- `server.js` — WebSocket init/update에 teams 데이터 추가
- `AgentManager.js` — teamMembers 캐시, 프로젝트명 기반 팀 이름 폴백
- `Camera.js` — followAgent/stopFollow/updateFollow lerp 메커니즘
- `IsometricRenderer.js` — selectAgentById, 대화 매칭, 카메라 팔로우 연결
- `AgentSprite.js` — 대화 시스템 (startChat/endChat, 말풍선 애니메이션)
- `App.js` — ActivityPanel 연결, 에이전트 선택/해제 이벤트 바인딩
- `ActivityPanel.js` — (신규) 우측 패널 컴포넌트, 토큰 렌더링
- `activity-panel.css` — (신규) 패널 스타일, 토큰 바, 그리드
- `index.html` — 우측 패널 + 토큰 섹션 HTML 추가

## Test plan
- [ ] 캐릭터 모드에서 에이전트 클릭 → 카메라 부드럽게 따라가는지 확인
- [ ] 우측 패널에 토큰 사용량, 도구 히스토리, 메시지 실시간 갱신 확인
- [ ] 컨텍스트 바 색상 변화 확인 (50% 주황, 80% 빨강)
- [ ] 팀 멤버 에이전트가 즉시 감지되는지 확인
- [ ] 드래그 시 카메라 팔로우 해제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)